### PR TITLE
Enable link time optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "=0.2.78"
 prisma-fmt = { git = "https://github.com/prisma/prisma-engines" }
+
+[profile.release]
+lto = true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Publish pipeline](https://github.com/prisma/prisma-fmt-wasm/actions/workflows/publish-prisma-fmt-wasm.yml/badge.svg)](https://github.com/prisma/prisma-fmt-wasm/actions/workflows/publish-prisma-fmt-wasm.yml)
 [![npm package](https://img.shields.io/npm/v/@prisma/prisma-fmt-wasm/latest)](https://www.npmjs.com/package/@prisma/prisma-fmt-wasm)
+[![install size](https://packagephobia.com/badge?p=@prisma/prisma-fmt-wasm)](https://packagephobia.com/result?p=@prisma/prisma-fmt-wasm)
 
 This repository only contains build logic to package the `prisma-fmt` engine into a Node package as a WASM module. All the functionality is
 implemented in [prisma-engines](https://github.com/prisma/prisma-engines/).


### PR DESCRIPTION
See: https://rustwasm.github.io/docs/book/reference/code-size.html#compiling-with-link-time-optimizations-lto

> This gives LLVM many more opportunities to inline and prune functions. Not only will it make the .wasm smaller, but it will also make it faster at runtime! The downside is that compilation will take longer.

With optimization:

```sh
# Before
> wc -c result/src/prisma_fmt_build_bg.wasm
2682725 result/src/prisma_fmt_build_bg.wasm

# After
> wc -c result/src/prisma_fmt_build_bg.wasm
2423812 result/src/prisma_fmt_build_bg.wasm
```