### PR TITLE
Disable link-time optimization

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v16
 
       # Checks

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,22 @@
+name: PR checks
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: Build checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Install nix
+      # Copy-pasted from https://github.com/marketplace/actions/install-nix
+      - uses: cachix/install-nix-action@v16
+
+      # Checks
+      - run: nix flake check .
+      - run: nix build .
+

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      # Install nix
-      # Copy-pasted from https://github.com/marketplace/actions/install-nix
       - uses: cachix/install-nix-action@v16
 
       # Checks

--- a/.github/workflows/publish-prisma-fmt-wasm.yml
+++ b/.github/workflows/publish-prisma-fmt-wasm.yml
@@ -26,15 +26,7 @@ jobs:
         run: |
           echo $THE_INPUT
 
-      # Install nix
-      # Copy-pasted from https://github.com/marketplace/actions/install-nix
-      - uses: cachix/install-nix-action@v14
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/install-nix-action@v16
 
       #
       # Update repository for the new engines version and package version

--- a/.github/workflows/publish-prisma-fmt-wasm.yml
+++ b/.github/workflows/publish-prisma-fmt-wasm.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build and publish @prisma/prisma-fmt-wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Print input
         env:

--- a/.github/workflows/update-system-dependencies.yml
+++ b/.github/workflows/update-system-dependencies.yml
@@ -9,16 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-
-      # Install nix
-      # Copy-pasted from https://github.com/marketplace/actions/install-nix
-      - uses: cachix/install-nix-action@v14
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/install-nix-action@v16
 
       #
       # Update flake.lock

--- a/.github/workflows/update-system-dependencies.yml
+++ b/.github/workflows/update-system-dependencies.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update build dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v16
 
       #

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.direnv
 /target
 /result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ crate-type = ["cdylib"]
 wasm-bindgen = "=0.2.79"
 wasm-logger = { version = "0.2.0", optional = true }
 prisma-fmt = { git = "https://github.com/prisma/prisma-engines" }
-
-[profile.release]
-lto = true

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         inherit (pkgs) wasm-bindgen-cli rustPlatform nodejs;
       in
       {
-        defaultPackage = rustPlatform.buildRustPackage {
+        packages.default = rustPlatform.buildRustPackage {
           name = "prisma-fmt-wasm";
           # https://nix.dev/anti-patterns/language#reproducibility-referencing-top-level-directory-with
           src = builtins.path { path = ./.; name = "prisma-fmt-wasm"; };
@@ -58,17 +58,11 @@
           installPhase = "echo 'Install phase: skipped'";
         };
 
-        packages = {
+        apps = {
           cargo = {
             type = "app";
             program = "${rust}/bin/cargo";
           };
-          # Takes the new package version as first and only argument, and updates package.json
-          updateNpmPackageVersion = pkgs.writeShellScriptBin "updateNpmPackageVersion" ''
-            ${pkgs.jq}/bin/jq ".version = \"$1\"" package.json > /tmp/package.json
-            rm package.json
-            cp /tmp/package.json package.json
-          '';
           npm = {
             type = "app";
             program = "${nodejs}/bin/npm";
@@ -77,6 +71,15 @@
             type = "app";
             program = "${wasm-bindgen-cli}/bin/wasm-bindgen";
           };
+        };
+
+        packages = {
+          # Takes the new package version as first and only argument, and updates package.json
+          updateNpmPackageVersion = pkgs.writeShellScriptBin "updateNpmPackageVersion" ''
+            ${pkgs.jq}/bin/jq ".version = \"$1\"" package.json > /tmp/package.json
+            rm package.json
+            cp /tmp/package.json package.json
+          '';
           syncWasmBindgenVersions = pkgs.writeShellScriptBin "updateWasmBindgenVersion" ''
             echo 'Syncing wasm-bindgen version in crate with that of the installed CLI...'
             sed -i "s/^wasm-bindgen\ =.*$/wasm-bindgen = \"=${wasm-bindgen-cli.version}\"/" Cargo.toml

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
           # - Cargo.lock
           # - datamodel-0.1.0.sha256sum
           updateLocks = pkgs.writeShellScriptBin "updateLocks" ''
+            set -euxo pipefail
             export DATAMODEL_CHECKSUM_FILE=datamodel-0.1.0.sha256sum
 
             nix run .#syncWasmBindgenVersions
@@ -95,7 +96,7 @@
             nix run .#cargo update
 
             if [[ $enginesHash != "" ]]; then
-              nix run .#cargo update -p datamodel --precise $enginesHash
+              nix run .#cargo -- update -p datamodel --precise $enginesHash
             fi
 
             echo 'Setting up fake checksum so the build can fail and output the new hash...'


### PR DESCRIPTION
The builds have been taking much longer lately, and in the last few days started timing out and getting killed. Disabling lto makes release builds complete in expected timeframes again. It was introduced in effa2c07