### PR TITLE
Fix exit code of updateLocks script

### DIFF
--- a/scripts/updateLocks.sh
+++ b/scripts/updateLocks.sh
@@ -16,7 +16,7 @@ echo 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' > \
   $DATAMODEL_CHECKSUM_FILE
 
 echo "Computing and inserting new datamodel checksum..."
-DATAMODEL_CHECKSUM=$(nix build 2>&1 1>&2 | awk '/got:/ {print $2}')
+DATAMODEL_CHECKSUM=$(nix build 2>&1 1>&2 | awk '/got:/ {print $2}' || true)
 export DATAMODEL_CHECKSUM
 
 echo "Installing new datamodel checksum ($DATAMODEL_CHECKSUM)..."


### PR DESCRIPTION
Since we use `set -e` to be stricter about failures, and propagate the
exit code of `nix build` by assigning to a _local_ variable first, the
build we expect to fail in order to get the sha of datamodel causes the
whole updateLocks script to return exit code 1.

We fix this by swallowing the exit code in that step.

that broke in https://github.com/prisma/prisma-fmt-wasm/pull/26