### PR TITLE
Rename updateLocks to updateDatamodelVersion and make it more robust

### DIFF
--- a/.github/workflows/publish-prisma-fmt-wasm.yml
+++ b/.github/workflows/publish-prisma-fmt-wasm.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Update Cargo.lock and engines source hash
         run: |
-          enginesHash="${{ github.event.inputs.enginesHash }}" nix run .#updateLocks
+          enginesHash="${{ github.event.inputs.enginesHash }}" nix run .#updateDatamodelVersion
 
       - name: Update NPM package version
         run: |

--- a/.github/workflows/update-system-dependencies.yml
+++ b/.github/workflows/update-system-dependencies.yml
@@ -24,6 +24,12 @@ jobs:
       - run: 'nix run .#syncWasmBindgenVersions'
 
       #
+      # Update other crate dependencies with `cargo update`
+      #
+
+      - run: nix run .#cargo update
+
+      #
       # Build to confirm that this did not break the build.
       #
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,8 @@
         };
 
         packages = {
+          inherit (pkgs) cargo;
+
           updateNpmPackageVersion = pkgs.writeShellApplication {
             name = "updateNpmPackageVersion";
             runtimeInputs = [ jq ];
@@ -50,10 +52,10 @@
               runtimeInputs = [ coreutils ];
               text = replaceStrings [ "$WASM_BINDGEN_VERSION" ] [ wasm-bindgen-cli.version ] template;
             };
-          updateLocks = pkgs.writeShellApplication {
-            name = "updateLocks";
+          updateDatamodelVersion = pkgs.writeShellApplication {
+            name = "updateDatamodelVersion";
             runtimeInputs = [ rust coreutils ];
-            text = readFile ./scripts/updateLocks.sh;
+            text = readFile ./scripts/updateDatamodelVersion.sh;
           };
         };
       });

--- a/scripts/updateDatamodelVersion.sh
+++ b/scripts/updateDatamodelVersion.sh
@@ -1,14 +1,15 @@
-# Updates:
+# Updates the checksums for the datamodel crate in:
 # - Cargo.lock
 # - datamodel-0.1.0.sha256sum
 set -euxo pipefail
 export DATAMODEL_CHECKSUM_FILE=datamodel-0.1.0.sha256sum
 
-echo 'Running cargo update...'
-cargo update
-
 if [[ ${enginesHash:?} != "" ]]; then
+  echo "Updating to enginesHash=${enginesHash:?}"
   cargo update -p datamodel --precise "$enginesHash"
+else
+  echo "/! \ ERROR /!\ No enginesHash was passed in for this script to update to."
+  exit 1
 fi
 
 echo 'Setting up fake checksum so the build can fail and output the new hash...'


### PR DESCRIPTION
- Rename updateLocks to updateDatamodelVersion
- Stop updating other dependencies when updating datamodel dependency,
  instead do it during the weekly sunday upgrades.
- Fail hard if enginesHash is not provided.
                                                                                   
The general aim of the PR is to isolate the failure mode in  https://github.com/prisma/prisma-fmt-wasm/issues/29 as much as possible.                                                                                   