### PR TITLE
fix(updateDatamodelVersion): force cargo to refetch git repos

### DIFF
--- a/scripts/updateDatamodelVersion.sh
+++ b/scripts/updateDatamodelVersion.sh
@@ -3,6 +3,8 @@
 # - datamodel-0.1.0.sha256sum
 set -euxo pipefail
 export DATAMODEL_CHECKSUM_FILE=datamodel-0.1.0.sha256sum
+CARGO_HOME=$(mktemp -d)
+export CARGO_HOME
 
 if [[ ${enginesHash:?} != "" ]]; then
   echo "Updating to enginesHash=${enginesHash:?}"


### PR DESCRIPTION
We achieve this by setting CARGO_HOME to a random empty directory, so we
are sure that cargo is not using any local cached checkout.

This is an attempt at solving https://github.com/prisma/prisma-fmt-wasm/issues/29